### PR TITLE
feat: update Exercise2/backend to use @aws-sdk/client-dynamodb@alpha

### DIFF
--- a/Exercise2/backend/package.json
+++ b/Exercise2/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Backend for the AWS JS SDK v3 workshop",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^1.0.0-alpha.6"
+    "@aws-sdk/client-dynamodb": "^1.0.0-alpha.10"
   },
   "scripts": {
     "build": "webpack",

--- a/Exercise2/backend/package.json
+++ b/Exercise2/backend/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Backend for the AWS JS SDK v3 workshop",
-  "dependencies": {
-    "@aws-sdk/client-dynamodb-node": "^0.1.0-preview.2"
-  },
+  "dependencies": {},
   "scripts": {
     "build": "webpack",
     "mb": "aws s3 mb s3://$AWS_JS_SDK_ID",

--- a/Exercise2/backend/package.json
+++ b/Exercise2/backend/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "description": "Backend for the AWS JS SDK v3 workshop",
-  "dependencies": {},
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^1.0.0-alpha.6"
+  },
   "scripts": {
     "build": "webpack",
     "mb": "aws s3 mb s3://$AWS_JS_SDK_ID",

--- a/Exercise2/backend/src/create.ts
+++ b/Exercise2/backend/src/create.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import dynamoDBClient from "./libs/dynamoDB";
-import { PutItemCommand } from "@aws-sdk/client-dynamodb-node";
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { success, failure } from "./libs/response";
 import { APIGatewayProxyEvent } from "aws-lambda";
 

--- a/Exercise2/backend/src/delete.ts
+++ b/Exercise2/backend/src/delete.ts
@@ -1,6 +1,6 @@
 import dynamoDBClient from "./libs/dynamoDB";
 import { success, failure } from "./libs/response";
-import { DeleteItemCommand } from "@aws-sdk/client-dynamodb-node";
+import { DeleteItemCommand } from "@aws-sdk/client-dynamodb";
 import { APIGatewayProxyEvent } from "aws-lambda";
 
 export async function main(event: APIGatewayProxyEvent) {

--- a/Exercise2/backend/src/get.ts
+++ b/Exercise2/backend/src/get.ts
@@ -1,6 +1,6 @@
 import dynamoDBClient from "./libs/dynamoDB";
 import { success, failure } from "./libs/response";
-import { GetItemCommand } from "@aws-sdk/client-dynamodb-node";
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { APIGatewayProxyEvent } from "aws-lambda";
 
 export async function main(event: APIGatewayProxyEvent) {

--- a/Exercise2/backend/src/libs/dynamoDB.ts
+++ b/Exercise2/backend/src/libs/dynamoDB.ts
@@ -1,3 +1,3 @@
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb-node";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
 export default new DynamoDBClient({});

--- a/Exercise2/backend/src/list.ts
+++ b/Exercise2/backend/src/list.ts
@@ -1,6 +1,6 @@
 import dynamoDBClient from "./libs/dynamoDB";
 import { success, failure } from "./libs/response";
-import { ScanCommand } from "@aws-sdk/client-dynamodb-node";
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
 
 export async function main() {
   const params = {

--- a/Exercise2/backend/src/update.ts
+++ b/Exercise2/backend/src/update.ts
@@ -1,6 +1,6 @@
 import dynamoDBClient from "./libs/dynamoDB";
 import { success, failure } from "./libs/response";
-import { UpdateItemCommand } from "@aws-sdk/client-dynamodb-node";
+import { UpdateItemCommand } from "@aws-sdk/client-dynamodb";
 import { APIGatewayProxyEvent } from "aws-lambda";
 
 export async function main(event: APIGatewayProxyEvent) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,14 +38,6 @@
   dependencies:
     tslib "^1.9.3"
 
-"@aws-sdk/abort-controller@^0.1.0-preview.7":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.7.tgz#3129f4b98e6e3c435ef15f8293330a2db135e2f4"
-  integrity sha512-UpAa0PQ4u1UdDYPU9ajO/vzfmSn3rTMjXQjlsd0Ue4oK/A2lffNN28+egMVuS+Ivs96pv1HAfA4t4tPw+U6wjA==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/apply-body-checksum-middleware@^0.1.0-preview.4":
   version "0.1.0-preview.8"
   resolved "https://registry.yarnpkg.com/@aws-sdk/apply-body-checksum-middleware/-/apply-body-checksum-middleware-0.1.0-preview.8.tgz#19a37c810c7f5f00cb5f4d194ad167b5b5b0aa81"
@@ -99,37 +91,6 @@
     "@aws-sdk/util-utf8-browser" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/client-dynamodb-node@^0.1.0-preview.2":
-  version "0.1.0-preview.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb-node/-/client-dynamodb-node-0.1.0-preview.2.tgz#7aab1eded26e9a4503313fed32bf23a42d042936"
-  integrity sha512-DQ9bTUquEShfYbBRir1KBCbapl5i5WM2GVdbmdbqYJP+5rwynYqbgrVWzn6Mt2azUgdkajfO+uY0fKhN2SvvVw==
-  dependencies:
-    "@aws-sdk/config-resolver" "^0.1.0-preview.2"
-    "@aws-sdk/core-handler" "^0.1.0-preview.2"
-    "@aws-sdk/credential-provider-node" "^0.1.0-preview.3"
-    "@aws-sdk/hash-node" "^0.1.0-preview.2"
-    "@aws-sdk/json-builder" "^0.1.0-preview.2"
-    "@aws-sdk/json-error-unmarshaller" "^0.1.0-preview.3"
-    "@aws-sdk/json-parser" "^0.1.0-preview.2"
-    "@aws-sdk/middleware-content-length" "^0.1.0-preview.2"
-    "@aws-sdk/middleware-header-default" "^0.1.0-preview.2"
-    "@aws-sdk/middleware-serializer" "^0.1.0-preview.2"
-    "@aws-sdk/middleware-stack" "^0.1.0-preview.3"
-    "@aws-sdk/node-http-handler" "^0.1.0-preview.3"
-    "@aws-sdk/protocol-json-rpc" "^0.1.0-preview.3"
-    "@aws-sdk/region-provider" "^0.1.0-preview.2"
-    "@aws-sdk/retry-middleware" "^0.1.0-preview.2"
-    "@aws-sdk/signature-v4" "^0.1.0-preview.3"
-    "@aws-sdk/signing-middleware" "^0.1.0-preview.3"
-    "@aws-sdk/stream-collector-node" "^0.1.0-preview.2"
-    "@aws-sdk/types" "^0.1.0-preview.2"
-    "@aws-sdk/url-parser-node" "^0.1.0-preview.2"
-    "@aws-sdk/util-base64-node" "^0.1.0-preview.1"
-    "@aws-sdk/util-body-length-node" "^0.1.0-preview.2"
-    "@aws-sdk/util-user-agent-node" "^0.1.0-preview.3"
-    "@aws-sdk/util-utf8-node" "^0.1.0-preview.1"
-    tslib "^1.8.0"
-
 "@aws-sdk/client-s3-browser@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3-browser/-/client-s3-browser-0.1.0-preview.2.tgz#b4c3eb5f19ad6bf99f8316bc2e169622fcdd72be"
@@ -174,7 +135,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/config-resolver@^0.1.0-preview.2", "@aws-sdk/config-resolver@^0.1.0-preview.4":
+"@aws-sdk/config-resolver@^0.1.0-preview.4":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.7.tgz#adb8077b3656cf7a890c6302c28f468665b76455"
   integrity sha512-clP/NFkGyIJzCPPZ9y9vc4rQD2O8euuEVtYDlHNPfe+791uo43I1/qhw20v31mPY1OH0dScf5Jn/n4Ed9YO1VA==
@@ -190,7 +151,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/core-handler@^0.1.0-preview.2", "@aws-sdk/core-handler@^0.1.0-preview.4":
+"@aws-sdk/core-handler@^0.1.0-preview.4":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.7.tgz#2deb6e8a64a4138ebfe8c4337bd84f48a3fdbb0d"
   integrity sha512-F+BAYmcPGbbK2w6Y9i4RgK9f8ojUuQKoZuFCxiYoujLGoak/p81gACTz3dQyV9/NiY46EvmdpyaGQeLtpfuriQ==
@@ -207,59 +168,6 @@
     "@aws-sdk/property-provider" "^0.1.0-preview.1"
     "@aws-sdk/protocol-timestamp" "^0.1.0-preview.1"
     "@aws-sdk/types" "^0.1.0-preview.1"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-env@^0.1.0-preview.8":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.8.tgz#ea8d22964e6041e0bfffb4085a366c6ed5d76a28"
-  integrity sha512-wW2XRalzx8jAIsVSdOM4cDP3hgbvPy6UJhQwpn9N3kfb22G5FPEry6hlJKHAVzQ15tkTNd0C6SyRlXgC5zEzmA==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.7"
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-imds@^0.1.0-preview.8":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.8.tgz#aa00e2fb2c92e4376f7727e3372a5f759ebc6225"
-  integrity sha512-l6qudUcrpfG8wGOCyOea1oZ42AF+m0h27m/BDvWA8KIclW6XjfJ0TAcQWNVYbDX91sBx3YWidqlNBuzs/bZfKw==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-ini@^0.1.0-preview.7":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.7.tgz#17691ba3ea7fcfe7923e2d109ba23485f3eab53a"
-  integrity sha512-iIVGZonHwy08RJgW9AZURKAbRTcBtwZw9wWSkO1YgtFVKYHH81E+C/k3o9ljCD9TK+XfvB2dv5alPkS71EufIQ==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.7"
-    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-node@^0.1.0-preview.3":
-  version "0.1.0-preview.10"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.10.tgz#29af30112b6ff06d8c66a9e4dffd1381747e07d3"
-  integrity sha512-UWw89x1kCTiawc2MWYjavChk1bwy4dlp8WZyYeM/a4MqYacXPbcIOXEDVVL72PpCOqtxk0/RXnkLO2b7sUI0vg==
-  dependencies:
-    "@aws-sdk/credential-provider-env" "^0.1.0-preview.8"
-    "@aws-sdk/credential-provider-imds" "^0.1.0-preview.8"
-    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.7"
-    "@aws-sdk/credential-provider-process" "^0.1.0-preview.5"
-    "@aws-sdk/property-provider" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-process@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.5.tgz#647c0afa0fc5e364ad956362b615ff40ba59e282"
-  integrity sha512-OIBmuaul/aF3w3oCc1zIw+jE5tlhacrhCD/LXf0DornF8Bfp4oaYA5qJ4Lttu/Q25s2qW5+YEuFlDsnqpIQUyw==
-  dependencies:
-    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.7"
-    "@aws-sdk/property-provider" "^0.1.0-preview.7"
-    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/fetch-http-handler@^0.1.0-preview.1":
@@ -287,15 +195,6 @@
   dependencies:
     "@aws-sdk/chunked-blob-reader" "^0.1.0-preview.3"
     "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
-"@aws-sdk/hash-node@^0.1.0-preview.2":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.8.tgz#7f6de5e60d1cf220aa548e2276fc24770efa5c03"
-  integrity sha512-tYBKE5ggAfw7oCLj3/jVJomruUMXhFOL+yH7xnKbgEjCi2m/jsSClCwjUbco2d5eFeC75t74RsFuyCREm9o+nw==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
 "@aws-sdk/is-array-buffer@^0.1.0-preview.1":
@@ -337,17 +236,6 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/json-builder@^0.1.0-preview.2":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/json-builder/-/json-builder-0.1.0-preview.7.tgz#1b0511671b1adc302c913bbde4199552bdab679b"
-  integrity sha512-gGrViVpR688e/3zQEXi7xb7/q4Nrz5w9DclJi6f32OHBphDkpv1SpHvf2WgA0949daU4QVKkyh0F6K2NygZtgg==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
-    "@aws-sdk/is-iterable" "^0.1.0-preview.3"
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/json-error-unmarshaller@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/json-error-unmarshaller/-/json-error-unmarshaller-0.1.0-preview.2.tgz#3f1698c057b3410c19898d276a9d53ea7e4ff8f7"
@@ -357,15 +245,6 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     "@aws-sdk/util-error-constructor" "^0.1.0-preview.1"
 
-"@aws-sdk/json-error-unmarshaller@^0.1.0-preview.3":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/json-error-unmarshaller/-/json-error-unmarshaller-0.1.0-preview.8.tgz#850c5d80a6f9ce3dbd37a6200eee567958e4c91d"
-  integrity sha512-yCua3FUxKIahjDugSdQMj8g+DNT+R5gViL2CYZ05kXaUla+Qml8UDV5bPr/z21FM91Oe2d532eORXixWnWCVOQ==
-  dependencies:
-    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.8"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    "@aws-sdk/util-error-constructor" "^0.1.0-preview.7"
-
 "@aws-sdk/json-parser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/json-parser/-/json-parser-0.1.0-preview.1.tgz#5c1c31c1b26cc56f23d33f69ba462051a22abe33"
@@ -373,15 +252,6 @@
   dependencies:
     "@aws-sdk/protocol-timestamp" "^0.1.0-preview.1"
     "@aws-sdk/types" "^0.1.0-preview.1"
-    tslib "^1.8.0"
-
-"@aws-sdk/json-parser@^0.1.0-preview.2":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/json-parser/-/json-parser-0.1.0-preview.7.tgz#d95bc98df7238fb9f1d0bacda1a7d8585b253559"
-  integrity sha512-EOcBUct4jkkUky+h3nw+jRo/eSREUFgqr0k9Cqcqsf6rSHN7+TCXT9tyo8CLpvDUPsbJj+Wmoylce04wU5HQkQ==
-  dependencies:
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/location-constraint-middleware@^0.1.0-preview.4":
@@ -409,7 +279,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-content-length@^0.1.0-preview.2", "@aws-sdk/middleware-content-length@^0.1.0-preview.4":
+"@aws-sdk/middleware-content-length@^0.1.0-preview.4":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.7.tgz#3e873c6886c737e02282f3507daa3348d85a368c"
   integrity sha512-6ZI+dY8VgWmKL48tBtFGFgllwdhKgqNztscLtYPmHl38zrz4sITJnyGwbYDGLW+xLIGDOQhyFd/6kWTqT9QyKQ==
@@ -425,7 +295,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-header-default@^0.1.0-preview.2", "@aws-sdk/middleware-header-default@^0.1.0-preview.4":
+"@aws-sdk/middleware-header-default@^0.1.0-preview.4":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.7.tgz#3083c6ed8dfa3c9d556941011b388789b84eb2cc"
   integrity sha512-hf7+YMiPnyzRKzmcZZ5v2NKkC6CKgo8nnckJ1A1OlvWYGq3hLMF1gKDMzdkEFjWJmDWv6AVNyHjw5qe4AV8LVA==
@@ -441,7 +311,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-serializer@^0.1.0-preview.2", "@aws-sdk/middleware-serializer@^0.1.0-preview.4":
+"@aws-sdk/middleware-serializer@^0.1.0-preview.4":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.7.tgz#7d4ed3d16b47f12f7ed0762ff9594c0f2da9c96c"
   integrity sha512-mc5xBnrdDM9k3a78cbTSw+VWTadpDQQBObSuAy4fCxrkPZa+APqRY+y9MMDQ0uWI80e6Ab1pt9wTx1/OM1uMWQ==
@@ -457,21 +327,11 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-stack@^0.1.0-preview.3", "@aws-sdk/middleware-stack@^0.1.0-preview.5":
+"@aws-sdk/middleware-stack@^0.1.0-preview.5":
   version "0.1.0-preview.9"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.9.tgz#e38a1ef131fee03382941bbcc2d70c4b5f77948f"
   integrity sha512-UZPTIUL8df6bxhoRFmbE278mR5VkBgUakZ+g0+W7QP7yk7yOcA/PSNAoUQMXmyncTfrv9PS2RqByIqBGJ9nHRw==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
-"@aws-sdk/node-http-handler@^0.1.0-preview.3":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.8.tgz#d301ca5bd7996ab5cb0d29f595aa37e6815e4b25"
-  integrity sha512-D3hISgch64L2rG8RQDi361ywoSgsyH/5Yj4ZF05ZCo8UZ8TjU1CtiLPKy1is0XLqojhLlDAQ65lNna44xoArcw==
-  dependencies:
-    "@aws-sdk/abort-controller" "^0.1.0-preview.7"
-    "@aws-sdk/querystring-builder" "^0.1.0-preview.7"
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
@@ -483,14 +343,6 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/property-provider@^0.1.0-preview.7":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.7.tgz#21ddb9b5f66403310f52ac7f286a9e6bc178f8c7"
-  integrity sha512-8yKkR78XC3fvdd+ePohfLuZHKBL7e3k+t82JL775phiXO94WHiz/hlvm6tGhNz5zKzz72yLrJPCyoQAZLrxrTg==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/protocol-json-rpc@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-json-rpc/-/protocol-json-rpc-0.1.0-preview.2.tgz#15913ba1b66511a3590734470461c5d6c2cfb112"
@@ -500,17 +352,6 @@
     "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.2"
     "@aws-sdk/types" "^0.1.0-preview.1"
     "@aws-sdk/util-error-constructor" "^0.1.0-preview.1"
-    tslib "^1.8.0"
-
-"@aws-sdk/protocol-json-rpc@^0.1.0-preview.3":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-json-rpc/-/protocol-json-rpc-0.1.0-preview.8.tgz#b8d52d4bc930bc946a2e0c44414fd55c1d98bd6d"
-  integrity sha512-HF7g/xE/mGLzaYqO5tDFqxFvHS4vbuLAmRsWnUKsNBzg+G9+r6XK+4+PrUKwEJT69lNXezUetjwuemqnycsStA==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
-    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.8"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    "@aws-sdk/util-error-constructor" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/protocol-rest@^0.1.0-preview.6":
@@ -587,16 +428,6 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/region-provider@^0.1.0-preview.2":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.7.tgz#dcb5cd10c712ae54fac605c5b4f08a30131ea21c"
-  integrity sha512-n+LeuQYPYbCyfCboz9mmYqcPPKdmdd60KPbPeRqSdJYr9QZz9hWU962oCOl5EtLYIsUzy7Fm33APv6toEcAPVw==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.7"
-    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/response-metadata-extractor@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.2.tgz#e437c43638ec1688df84e6041b0ce201caa37c8e"
@@ -622,7 +453,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/retry-middleware@^0.1.0-preview.2", "@aws-sdk/retry-middleware@^0.1.0-preview.4":
+"@aws-sdk/retry-middleware@^0.1.0-preview.4":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.7.tgz#4923089c9a2c5306c91489fd7d041f70f4b597e2"
   integrity sha512-ULiq+dffOPurjyHm95PYWi1Cy27LQg9jPwLz5tiL7oIla/j9b5bcclZE3n0RtqbHDUvWJL5kxmYw0Kjrggr5iw==
@@ -662,14 +493,7 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-0.1.0-preview.3.tgz#6e3720f361f637d0dbcff09f487997fa2ce3018d"
   integrity sha512-3TXwADJL+HGOWyqdwx+pOdwr8L8LGbdxwHR0D05PP3skY+TP34F3ye2DJlyCll4S9vYzf9GlSbwJWviN9Sujrw==
 
-"@aws-sdk/shared-ini-file-loader@^0.1.0-preview.3":
-  version "0.1.0-preview.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.3.tgz#215c5ed06564eb5ba96fa615f1ccb66667725147"
-  integrity sha512-1wuV2YpZm+sW4AZa7CBD3A3b7+vSHX0DWBgGaENYdqC+MUEl6lD57ZOUGLryPq5xv/tQfy8BC7QT+qDNHElcuw==
-  dependencies:
-    tslib "^1.8.0"
-
-"@aws-sdk/signature-v4@^0.1.0-preview.10", "@aws-sdk/signature-v4@^0.1.0-preview.3", "@aws-sdk/signature-v4@^0.1.0-preview.5":
+"@aws-sdk/signature-v4@^0.1.0-preview.10", "@aws-sdk/signature-v4@^0.1.0-preview.5":
   version "0.1.0-preview.10"
   resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.10.tgz#d0a7275c28e1473550a0159d221eb697bdb8a98f"
   integrity sha512-cehCmWlWc16d1mn1tdG1cLdLUiKWHSVSAIiDRCyUS/ryZNduFHivYMyARvuQKEBXILlQari0e6RRuzTFXaAjlA==
@@ -700,7 +524,7 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/signing-middleware@^0.1.0-preview.3", "@aws-sdk/signing-middleware@^0.1.0-preview.5":
+"@aws-sdk/signing-middleware@^0.1.0-preview.5":
   version "0.1.0-preview.10"
   resolved "https://registry.yarnpkg.com/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.10.tgz#906ff790653c6a07563d9aed5e4805ce276668c0"
   integrity sha512-aKyPNr41JuOhl3QGqGp+XSerwPRbkG/TzBHiNsRX/0EeB1ZyxZ2cckhssswL3k4lvEBPQS0SqnGi2FHXozyOvw==
@@ -733,20 +557,12 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/stream-collector-node@^0.1.0-preview.2":
-  version "0.1.0-preview.9"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.9.tgz#ebb412dc7ebbb069ceb972627c8a9895ace14103"
-  integrity sha512-aXVMbx9lMd+AsmTpn4egsIJ/ZAkd6cWkhv8y3sL/Fwlyl0U7tfV4EzTEDZFvAta+MG+wB8fPhz9d7bfyQOk/xQ==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/types@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.1.tgz#6119574f873ec9a8ee2e5c1fbfb3ddcc9059c2f3"
   integrity sha512-CcZpxyN2G0I7+Jyj0om3LafYX7d30JWJAAQ+53Ysjau7jyL/xLMMkLZgniQPV8BMV7uKLXyf4hwu8JSs0Ejb+w==
 
-"@aws-sdk/types@^0.1.0-preview.2", "@aws-sdk/types@^0.1.0-preview.4", "@aws-sdk/types@^0.1.0-preview.7":
+"@aws-sdk/types@^0.1.0-preview.4", "@aws-sdk/types@^0.1.0-preview.7":
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.7.tgz#2c3e8b911c9236e8f48d8ffb3c9df449a067df58"
   integrity sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw==
@@ -769,15 +585,6 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/url-parser-node@^0.1.0-preview.2":
-  version "0.1.0-preview.8"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.8.tgz#d8863b852777b86d21d5693d11cf211d1a69443f"
-  integrity sha512-h8YwL+mLTBPNzryREkLChhtRSdz70tOR9y/UB6PATGKoJbMUFoTsDY1jbJ4WWBfdKjphZy9xVWTyxoCkP07tQQ==
-  dependencies:
-    "@aws-sdk/querystring-parser" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/util-base64-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-0.1.0-preview.1.tgz#95455d5ab0b58479c67540c110626392f139c34f"
@@ -792,14 +599,6 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/util-base64-node@^0.1.0-preview.1":
-  version "0.1.0-preview.1"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-0.1.0-preview.1.tgz#88c9e1392e1f4cd3ec4244e3c72b86c02344d651"
-  integrity sha512-EfPluf8bxq8LZpes9XxrxaEDfAilb9iqXphkR0UiLU0MWLJQaowrOjsS4lXRdSt9fXVIg3/zTyGxkDWoIM01wA==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "^0.1.0-preview.1"
-    tslib "^1.8.0"
-
 "@aws-sdk/util-body-length-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-0.1.0-preview.1.tgz#9d5126e0a63796f494b286f76ad6b6b2aba22eb7"
@@ -812,29 +611,6 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-0.1.0-preview.3.tgz#10a8653ca94d61d0333f1697958ddc8e4e4a901f"
   integrity sha512-vgESasjK299D8nNVx/DQx0My6Watz6xnGXtuoNbboEn81D4FLRpjcHydFoii1QXLeTYDZd9jLv+p9aozxIRLgQ==
   dependencies:
-    tslib "^1.8.0"
-
-"@aws-sdk/util-body-length-node@^0.1.0-preview.2":
-  version "0.1.0-preview.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-0.1.0-preview.2.tgz#443a670cfb9274c9b77d25c7ab3a231bc4859886"
-  integrity sha512-7jkPuo8zJO3MQ1ELpDo1n9xtBf63g+tdtdouZkaX5iITUyDSL4t3S9vIgAK1IQvJPBjtTkXzRO3CrQKW/SakEQ==
-  dependencies:
-    tslib "^1.8.0"
-
-"@aws-sdk/util-buffer-from@^0.1.0-preview.1":
-  version "0.1.0-preview.1"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-0.1.0-preview.1.tgz#b40c674044bf0997e0f170f692fbdaf7f5edd78c"
-  integrity sha512-i46iuFQA05+92L/epK7befgoxw6DM38LnaHjHNxRoJeIYUllZvpJst74FRCJ5UvVOaMDvHO3woWG+dY8/KVABw==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "^0.1.0-preview.1"
-    tslib "^1.8.0"
-
-"@aws-sdk/util-buffer-from@^0.1.0-preview.3":
-  version "0.1.0-preview.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-0.1.0-preview.3.tgz#a95aa03f6d82dccd853b110f15c5479c83204c58"
-  integrity sha512-n78cUmI1SbluJgTgyqp24GgNQ3A5NUGB4rwRAoID7k7JpsiNJUWTXkijl3hxfNov2sEjMWvdQIGvAF6F/Q2mfw==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
 "@aws-sdk/util-create-request@^0.1.0-preview.2":
@@ -930,14 +706,6 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/util-user-agent-node@^0.1.0-preview.3":
-  version "0.1.0-preview.10"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.10.tgz#d9f2c731883fa7d7a0fe806bab0e8e70506985c5"
-  integrity sha512-hYL9XCLkxDEG60XbwXG2fvIYwi9vFHw9Em6OPMz3sh3Y4er7KJxOwuCYJV+kccREY35e1TGblbOARFczwD7U0w==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.7"
-    tslib "^1.8.0"
-
 "@aws-sdk/util-utf8-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-0.1.0-preview.1.tgz#21142dfea0b143f8d73e0aabcbcafd76df1691f0"
@@ -950,14 +718,6 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-0.1.0-preview.3.tgz#ee0f829a63f35d1bab23467c3e1e67f451e04816"
   integrity sha512-l97pohYxDjrew/cLgItvPo4HIrH3Se4PsEwZ2tgNhpA2+p9iWJFPy2Lppngx1sk5s6QhGF3x1g4G/0dGYIObgQ==
   dependencies:
-    tslib "^1.8.0"
-
-"@aws-sdk/util-utf8-node@^0.1.0-preview.1":
-  version "0.1.0-preview.1"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-0.1.0-preview.1.tgz#f776a087039df1825b83d9d8680a47f8172721ca"
-  integrity sha512-PSUsSJ0nnMPS389f0R3kIVR0BElnEb22Ofj40iO5HCtw9gZ1ot+enFdbOmW4m1e5+ED9U/Hqxqc7QhFWWF4NUQ==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
 "@aws-sdk/xml-body-builder@^0.1.0-preview.4":

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,14 @@
   dependencies:
     tslib "^1.9.3"
 
+"@aws-sdk/abort-controller@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-1.0.0-alpha.2.tgz#cadc7608dd8f20eee2534590eef2d1bdfde14a79"
+  integrity sha512-f6MOmq7xFES9Z3JU4k9Eil8XB6Xg7XkomHWI//lcosbILmkj2skxjpK3+Xo25FbJws301tQdOnD6JoO+10obXg==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/apply-body-checksum-middleware@^0.1.0-preview.4":
   version "0.1.0-preview.8"
   resolved "https://registry.yarnpkg.com/@aws-sdk/apply-body-checksum-middleware/-/apply-body-checksum-middleware-0.1.0-preview.8.tgz#19a37c810c7f5f00cb5f4d194ad167b5b5b0aa81"
@@ -89,6 +97,43 @@
     "@aws-sdk/util-body-length-browser" "^0.1.0-preview.1"
     "@aws-sdk/util-user-agent-browser" "^0.1.0-preview.2"
     "@aws-sdk/util-utf8-browser" "^0.1.0-preview.1"
+    tslib "^1.8.0"
+
+"@aws-sdk/client-dynamodb@^1.0.0-alpha.6":
+  version "1.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-1.0.0-alpha.6.tgz#2bb4dbad9f9d78d9e3e087845976645c4d5fe121"
+  integrity sha512-pMxy/gUg7MUS1NxtuqtlJbTCDY3GLBBbAHdkmLso+FAjthMHpQbGyMuJFc6L2eogkLI/GUP8JcUKfZJ7jvS/VA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "^0.1.0-preview.1"
+    "@aws-sdk/config-resolver" "^1.0.0-alpha.4"
+    "@aws-sdk/credential-provider-node" "^1.0.0-alpha.2"
+    "@aws-sdk/fetch-http-handler" "^1.0.0-alpha.3"
+    "@aws-sdk/hash-node" "^1.0.0-alpha.2"
+    "@aws-sdk/invalid-dependency" "^1.0.0-alpha.2"
+    "@aws-sdk/middleware-content-length" "^1.0.0-alpha.3"
+    "@aws-sdk/middleware-host-header" "^1.0.0-alpha.3"
+    "@aws-sdk/middleware-retry" "^1.0.0-alpha.3"
+    "@aws-sdk/middleware-serde" "^1.0.0-alpha.2"
+    "@aws-sdk/middleware-signing" "^1.0.0-alpha.4"
+    "@aws-sdk/middleware-stack" "^1.0.0-alpha.2"
+    "@aws-sdk/middleware-user-agent" "^1.0.0-alpha.3"
+    "@aws-sdk/node-http-handler" "^1.0.0-alpha.3"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/region-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/smithy-client" "^1.0.0-alpha.2"
+    "@aws-sdk/stream-collector-browser" "^1.0.0-alpha.2"
+    "@aws-sdk/stream-collector-node" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/url-parser-browser" "^1.0.0-alpha.2"
+    "@aws-sdk/url-parser-node" "^1.0.0-alpha.2"
+    "@aws-sdk/util-base64-browser" "^1.0.0-alpha.2"
+    "@aws-sdk/util-base64-node" "^1.0.0-alpha.2"
+    "@aws-sdk/util-body-length-browser" "^1.0.0-alpha.2"
+    "@aws-sdk/util-body-length-node" "^1.0.0-alpha.2"
+    "@aws-sdk/util-user-agent-browser" "^1.0.0-alpha.3"
+    "@aws-sdk/util-user-agent-node" "^1.0.0-alpha.3"
+    "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.2"
+    "@aws-sdk/util-utf8-node" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/client-s3-browser@^0.1.0-preview.2":
@@ -143,6 +188,15 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/config-resolver@^1.0.0-alpha.4":
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-1.0.0-alpha.4.tgz#d80070744b157270591f851dfb30dad2ac4d6355"
+  integrity sha512-UGZ87h+UCzC6SwadbGOJS4wCv/LOxHEC9uIc/FfIjhed5DJcc6vDpANw+yLoq89BP0SKbpMavPLA4zkLVdXj4g==
+  dependencies:
+    "@aws-sdk/signature-v4" "^1.0.0-alpha.4"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/core-handler@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.1.tgz#139527b570ca0ae66a0c79a2a41fb685ded61064"
@@ -170,6 +224,59 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
+"@aws-sdk/credential-provider-env@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-1.0.0-alpha.2.tgz#206c1eccfccec0112d73e83d9be8ceae2669398e"
+  integrity sha512-6ux0bIp7yEjt9OLyy6O0k3HN1rZjthnQmvS6ryyIM6vCTGT37s7ys5BPqTdbg3U87F0enLMsZCkxdKM97eyTxA==
+  dependencies:
+    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-timestamp" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-imds@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-1.0.0-alpha.2.tgz#9212b8d44d3c73fb2c5877d21516e622cd7af90b"
+  integrity sha512-p0ApBjQ4eUSN0WEl2yPPO2P6zR99sAw/uz9SZ5Lc80lhOtQ2t6wZ66eydCxcaHmwR1xZV4L8CRsPi+LyZwOPgw==
+  dependencies:
+    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-ini@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-1.0.0-alpha.2.tgz#8d344451a537b0c0332d0c89ecf98767561c8409"
+  integrity sha512-qzuZdiL177W3jjLMrpOz1ilobemGKKq4HpBcxtc0OhctwkLBSCO/drDwwhjfJucBGJcQP+OnubdcM+MBxaPgJg==
+  dependencies:
+    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/shared-ini-file-loader" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-1.0.0-alpha.2.tgz#01f5cfbc9450f815c35e966f1597228add5110a8"
+  integrity sha512-8HNFtzt2OWlUmM5H9ec8+InN8GQpTmNP7ejWwFtCgkWVqfwWkgVs0gNg2zWuJFfAg+b+WLqHQGq+Xd8Vcy9H/g==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^1.0.0-alpha.2"
+    "@aws-sdk/credential-provider-imds" "^1.0.0-alpha.2"
+    "@aws-sdk/credential-provider-ini" "^1.0.0-alpha.2"
+    "@aws-sdk/credential-provider-process" "^1.0.0-alpha.2"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-process@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-1.0.0-alpha.2.tgz#6395a033d390e70bd9cc8cf9f99096632773859a"
+  integrity sha512-106a1jjVoj4jdBlAkL06xRPk6gmJqGKF9IqGff81xs/DiIz9qjrEZKFFQwJwYRuOwpJQpI6xIeYx77nRu8/6cA==
+  dependencies:
+    "@aws-sdk/credential-provider-ini" "^1.0.0-alpha.2"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/shared-ini-file-loader" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/fetch-http-handler@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-0.1.0-preview.1.tgz#9af957bf206422cb2d767cecedf3709ad16aa679"
@@ -188,6 +295,16 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/fetch-http-handler@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-alpha.3.tgz#387c50824931543c83856eb02496b9807cdc2984"
+  integrity sha512-uYWktJQvA8vzY0DVnepGJgrVhtXwKwwaOv4dl4vqBWI4Ou9b2rSluN/A6xQRi056r5FD11T4805oNXhIw1VcTg==
+  dependencies:
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/querystring-builder" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/hash-blob-browser@^0.1.0-preview.5":
   version "0.1.0-preview.9"
   resolved "https://registry.yarnpkg.com/@aws-sdk/hash-blob-browser/-/hash-blob-browser-0.1.0-preview.9.tgz#70011645fb16e373c9167fb7f057b140abf44be3"
@@ -195,6 +312,22 @@
   dependencies:
     "@aws-sdk/chunked-blob-reader" "^0.1.0-preview.3"
     "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/hash-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-1.0.0-alpha.2.tgz#a2d20d05de7ca22bf332e75177adb94c910fb077"
+  integrity sha512-dRotBDMsez8025XpC3f0b02wtoy+MdIN/BTLEsQrBdIUP85VmT8Jk6oJ1zrAGY7hm4GAZD78Lm13HLbkB3+17Q==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/util-buffer-from" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/invalid-dependency@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-1.0.0-alpha.2.tgz#b0c5fd864b551fcb5d99c3957357831468edce23"
+  integrity sha512-vfTAwg538PAY5UCZ8dIwRT0k6DEdo3THnpgciiwnxMOsVpeK+Nq3t1PN3F0Sn61KOfKp8+oPk4JA6sbqtml0lg==
+  dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/is-array-buffer@^0.1.0-preview.1":
@@ -208,6 +341,13 @@
   version "0.1.0-preview.3"
   resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-0.1.0-preview.3.tgz#3d4e0297f437dfaa00b25a000d526c02ccd2af6d"
   integrity sha512-8SM7kBGkwH6JCKA6K1w4Jrj+EABFOPQkbPvwaf6BILYiUMUbgJvjOPjNQE2MrvRxJz50WAcZDHnlwhstuwIRnw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/is-array-buffer@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-alpha.2.tgz#5434984954726210b0f770bbecfc62b214029e44"
+  integrity sha512-QXi/w4lCpIFg2LrbzM4CNT8OaftTDJqTXeZi09FL65il6NQ46jhNn8vsDQaVCw6K0fXR0VJZ09YcProT4B6IeA==
   dependencies:
     tslib "^1.8.0"
 
@@ -287,6 +427,15 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/middleware-content-length@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-alpha.3.tgz#f38adc78be2e2be3be52d4969f26d4bc73e427e7"
+  integrity sha512-ISfJkE+MTK83ntGZkuwCkwArWwxdz5b5hNkjIIu9C7SFV2ZpfrOBRw+ZnioCDo1Vv2mP3wusO55VVvYbkIQ2Zg==
+  dependencies:
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/middleware-header-default@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.1.tgz#7dc2a59f985ab6b3a3c1f388d3c228220d0ee878"
@@ -301,6 +450,32 @@
   integrity sha512-hf7+YMiPnyzRKzmcZZ5v2NKkC6CKgo8nnckJ1A1OlvWYGq3hLMF1gKDMzdkEFjWJmDWv6AVNyHjw5qe4AV8LVA==
   dependencies:
     "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-host-header@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-1.0.0-alpha.3.tgz#bfcec9e1ab65dfcd12b5efd281b752c3cf441e4a"
+  integrity sha512-nzy4aSSHg2vtC/qsRKZ7Y3CUKxLIVduAOqGq0hYL6zWoyCDcoMdSwTKYjR8XmW5tPBeEwsm2oEfutbm+tv2mvg==
+  dependencies:
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-retry@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-alpha.3.tgz#e8dc678db970106019bbb5ae9f4c5d6c22aefb29"
+  integrity sha512-TU/9bv27H418uMvQR1KddFhyBO7D+R5i4uR9UV+qjSz1jch2y3u6Nmot6ISsWCGdIT+wxhRXsV8BJml16lL+3w==
+  dependencies:
+    "@aws-sdk/service-error-classification" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-serde@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-1.0.0-alpha.2.tgz#7e0984833a66931779d0935a9423aace10678a95"
+  integrity sha512-Pkv67GrtXgqoeX+XWAd/G/T1YAhcunVwWh9zD1+nIeWNyrI7wGzrWRbhYCgvCsL+qf9kxyd6fV5jGu6dBlfLXg==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/middleware-serializer@^0.1.0-preview.1":
@@ -319,6 +494,16 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/middleware-signing@^1.0.0-alpha.4":
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-1.0.0-alpha.4.tgz#97ad364434af219a225ee33b837b9093c64d6782"
+  integrity sha512-PlqJc/mQ9nMzipGjddiJ1fGcgVwzM9dKqVaSg/Me/+XpFASjHpUIf00DGWC3W/7dynRCFd+57KMBnvlz+grC+A==
+  dependencies:
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/signature-v4" "^1.0.0-alpha.4"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/middleware-stack@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.2.tgz#f570e8f5e065a41285518d126a04d59728eb9a76"
@@ -335,12 +520,57 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/middleware-stack@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-1.0.0-alpha.2.tgz#772aad64fb7f0725cbaff1967a3a1f518078ad15"
+  integrity sha512-meLHoDz0RlDIn1dC4eWgSmkr69ZyFua+QcSaWQG5IhzyG1x8zW2k49uYSaeUXS14mv8W+vHMQYCZLgrtFoUyNA==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-user-agent@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-1.0.0-alpha.3.tgz#0e2f120454f5a07aed688d5205a53fb76b6c216d"
+  integrity sha512-wtFcOf3QadfA0tc9rvjL9YIzlg90brjpqEmGWF1/k7cpWwHXiYbVN35I+FhrumGpTBpl8QqWzYnGttKGeBd4oA==
+  dependencies:
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/node-http-handler@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-1.0.0-alpha.3.tgz#b03a9e1f6c47759161ef7e8c32a4fd0c7e63704d"
+  integrity sha512-VdeUPdi48CJRxZG5Q+sC2ErutPrnA3R2sUFRImxEeqRlQeyy7BkS+NvmN7TyxFVX85NgPpl+WWOO0LE1PLVs7A==
+  dependencies:
+    "@aws-sdk/abort-controller" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
+    "@aws-sdk/querystring-builder" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/property-provider@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.1.tgz#2be71a5b1449ced5917307325274f39ed75c2fa6"
   integrity sha512-vEN4rqhOqw9XHaFNtwSG+Zqw8r8DGeqhDICqdwZk+NJKyP1+01UpZCMhCJw62kWmQwqfYqMYKVx7yENeDwT2ew==
   dependencies:
     "@aws-sdk/types" "^0.1.0-preview.1"
+    tslib "^1.8.0"
+
+"@aws-sdk/property-provider@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-1.0.0-alpha.2.tgz#ad1fd38cfd8ce6bb860045b3ab1ab9e32280be9e"
+  integrity sha512-z/jVTlZz1k7TaK6nei4oRXv0/AL8hz13+lP6XLZJ3Ljiv5v/kIhPVZolytUEBzHAu+58d44y5JhdPWkiPs9JAA==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/protocol-http@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-1.0.0-alpha.3.tgz#552702d87e60aa09939bbcd467c3fb1912495cd6"
+  integrity sha512-+r1h57HOEsO6/PLZrpHwzV3U4JganGfTETsPZbJZ1pkg/sKJ8xeHta0W1LwuDtgiwUwSN3P4cbh1gEHCMv5efw==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/util-uri-escape" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/protocol-json-rpc@^0.1.0-preview.2":
@@ -384,6 +614,14 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/protocol-timestamp@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-timestamp/-/protocol-timestamp-1.0.0-alpha.2.tgz#10a54cf647cc9c4d5c8de5268befdc060587c910"
+  integrity sha512-RMvn1M+b1cirX45EQy+TbDT71/CaMtRdZXqlIM9buXAJoWMDbHr/mVZb/6FMdujGwIctPX1RT375vdPVFlu37g==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/query-error-unmarshaller@^0.1.0-preview.5":
   version "0.1.0-preview.8"
   resolved "https://registry.yarnpkg.com/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.8.tgz#bcee4a3adda59b63e21eee220f13b1be7ddb8549"
@@ -412,6 +650,15 @@
     "@aws-sdk/util-uri-escape" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
+"@aws-sdk/querystring-builder@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-1.0.0-alpha.2.tgz#8ba59c57ff2a09f3ade12025ae55cc0c6583c1a3"
+  integrity sha512-UzKLbCcYZs+csaQ/C/BKbSf8G3m+WHkfQpYlSEBPnqBKZrbWMzCT1fZ0N/mR573g9dYGVEg08UIyrtawyVDejQ==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/util-uri-escape" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/querystring-parser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.1.tgz#128e7f0f52798d628f58b82c10c2fd3df66b540d"
@@ -426,6 +673,24 @@
   integrity sha512-r72E/wZYrhTXTK950Ld/L2Loso/HDqExQkIuCn1Pu8Rx0+uC3Y8fQTx+JZd5M5kOniCpGKdHWGc7y/bH/tjH4A==
   dependencies:
     "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/querystring-parser@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-1.0.0-alpha.2.tgz#cebd9f0b5869cfb4cb6d2d9afd6ba73332645bfd"
+  integrity sha512-QdahFldlVOr6bptZpAadyyXHU3kZ9DfBFj+rCp127EvmwX9ipNT1aClAN0e3gT39UgTfNOPWQL8lORZrmFHoOQ==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/region-provider@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-1.0.0-alpha.2.tgz#2dc934327d6895d334bdd6d886932a345ac5f171"
+  integrity sha512-KWGU8kbHPUFUvz03bM56eX3qimt8/8Twlet0HdYOw4ZMOaSZouNSqICUoW10zaNJbB2OP0h7p6O5Sj0pa+7D7A==
+  dependencies:
+    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/shared-ini-file-loader" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/response-metadata-extractor@^0.1.0-preview.2":
@@ -493,6 +758,18 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-0.1.0-preview.3.tgz#6e3720f361f637d0dbcff09f487997fa2ce3018d"
   integrity sha512-3TXwADJL+HGOWyqdwx+pOdwr8L8LGbdxwHR0D05PP3skY+TP34F3ye2DJlyCll4S9vYzf9GlSbwJWviN9Sujrw==
 
+"@aws-sdk/service-error-classification@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-1.0.0-alpha.2.tgz#12884cd28698f0aa4b68114d84ad931afd3b1c49"
+  integrity sha512-yuMLMN4N0dC2dioa3hTG5DYdhV9lrnd2QGZCEf+Pd1Xdtn8JvqPSNAHG2jUxeLlL/CQiYJ/J84jOjTxEEzAcCg==
+
+"@aws-sdk/shared-ini-file-loader@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-1.0.0-alpha.2.tgz#f23f4fa1a61c19d102396d7ca8996266b82e3a4f"
+  integrity sha512-uduef441VzFoOK6pVDR0UxRajYZQuRs00T4C9LZOlTJ1140Hl0UN5/bOhC4F5nAE3wigzILMj0/FYNPT6NCw1Q==
+  dependencies:
+    tslib "^1.8.0"
+
 "@aws-sdk/signature-v4@^0.1.0-preview.10", "@aws-sdk/signature-v4@^0.1.0-preview.5":
   version "0.1.0-preview.10"
   resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.10.tgz#d0a7275c28e1473550a0159d221eb697bdb8a98f"
@@ -515,6 +792,17 @@
     "@aws-sdk/util-hex-encoding" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
+"@aws-sdk/signature-v4@^1.0.0-alpha.4":
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-1.0.0-alpha.4.tgz#44eddb517dfc0b4d9d6f68493f96a130fb250bd2"
+  integrity sha512-sTrQWhYeyJj7lVRgEMvae4gh9DWBMDiReeVk8z40r54EqpholNckEp226SM2Yxj23Zffc/Ou6ny8wzwPv9Mu8w==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-timestamp" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/util-hex-encoding" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/signing-middleware@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.2.tgz#c249b157d721c9e3593c00773dd9c552905b317c"
@@ -531,6 +819,15 @@
   dependencies:
     "@aws-sdk/signature-v4" "^0.1.0-preview.10"
     "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/smithy-client@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-1.0.0-alpha.2.tgz#ac6bed90759740558e9ff207a7f5e5a7a3add173"
+  integrity sha512-tIWeWNK4H24TJedBFhy+oCvzrsl6UvOKUoIChjiVTgZ7t63IkLKXU+4jxhojQVeGZkQEEqa6K5/5MbdkshQeKA==
+  dependencies:
+    "@aws-sdk/middleware-stack" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/ssec-middleware@^0.1.0-preview.4":
@@ -557,6 +854,22 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/stream-collector-browser@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-browser/-/stream-collector-browser-1.0.0-alpha.2.tgz#bbf7cc036bb1ef9575a6b9e8b5a08a4d406fd4a0"
+  integrity sha512-YBegxJzoykaqb59bPBU18RetxK20P3Dz7lYcTvKVle5xxBjkq+FI0jChSx5cN5fV/d/UTEkjMG5H5ptp7fDFmA==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/stream-collector-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-1.0.0-alpha.2.tgz#7b74371388f05133cedf2c8ff263e1777e73b85f"
+  integrity sha512-LN8sKskKGappvGWvjXZPUGbEhpA+cucfTJ8EjBF8PeICxkQfMuTOaU6dnZVEI+1j0wd1UTg/e/QaW6vtnnq2kw==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/types@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.1.tgz#6119574f873ec9a8ee2e5c1fbfb3ddcc9059c2f3"
@@ -566,6 +879,11 @@
   version "0.1.0-preview.7"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.7.tgz#2c3e8b911c9236e8f48d8ffb3c9df449a067df58"
   integrity sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw==
+
+"@aws-sdk/types@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-1.0.0-alpha.2.tgz#0d2895ed9ba7dfaf0a4bbaf47f477ff49c5eada0"
+  integrity sha512-IiRAkOfrRy4Ck1YlQ39oMxrZnbmiMUZGLmfFCC7WY3BrYy6kp+kZUwxcPUtjK4ZtlDHEPd6XiJeo2MQ68kkXSA==
 
 "@aws-sdk/url-parser-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
@@ -585,6 +903,24 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/url-parser-browser@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-browser/-/url-parser-browser-1.0.0-alpha.2.tgz#ff258f2a3af00f4f7b1b24cfdb99a25ab2f781cc"
+  integrity sha512-wxwWEdzNj4oPjti3soeuhvu0ELqOkdFEsQv7dZd4PaMXWpnD7c1TX2f6bQicGJxwzIfnB3+vK3R5uCU4u5B7aQ==
+  dependencies:
+    "@aws-sdk/querystring-parser" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/url-parser-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-1.0.0-alpha.2.tgz#f5330430437ba88198eaf0105eaab221691d099d"
+  integrity sha512-GSFLb+wCcHMX8ebb+vL9LlkCcrhOyPeEj5IhlEQfLQnZ9n7Sl7G3wYizcptWtxARNHJXoAKwcMpOZHVSDi1Exw==
+  dependencies:
+    "@aws-sdk/querystring-parser" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/util-base64-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-0.1.0-preview.1.tgz#95455d5ab0b58479c67540c110626392f139c34f"
@@ -599,6 +935,21 @@
   dependencies:
     tslib "^1.8.0"
 
+"@aws-sdk/util-base64-browser@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-1.0.0-alpha.2.tgz#2d53b23b96feacfe03ebf33f92296a5461e54c86"
+  integrity sha512-b+DMgBjaErjF/XweTz0M2c2qi5h0CLeNrNZjA9fY7l6pfRYG1DA+WOjPLOu3A8I1ZaMDHYk6nPA3nDJPk/d29w==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-base64-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-1.0.0-alpha.2.tgz#49aeae132e8826599c0b83362eb2a25029a28fd2"
+  integrity sha512-pLM3vTBKRT1cYt4aIvDcSe+FKVHLdoumsOYxbiT51kxXg/eHp2LdDW+xK5Lp4MephUiXRG2FZs5VUomSIOna0Q==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/util-body-length-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-0.1.0-preview.1.tgz#9d5126e0a63796f494b286f76ad6b6b2aba22eb7"
@@ -611,6 +962,28 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-0.1.0-preview.3.tgz#10a8653ca94d61d0333f1697958ddc8e4e4a901f"
   integrity sha512-vgESasjK299D8nNVx/DQx0My6Watz6xnGXtuoNbboEn81D4FLRpjcHydFoii1QXLeTYDZd9jLv+p9aozxIRLgQ==
   dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-body-length-browser@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-1.0.0-alpha.2.tgz#005a1e6e61b5b6148e7288638f9db8b418c0b989"
+  integrity sha512-xIYWEeAPDsL5G8g1guPuwqZOqn/Zfi4+lu2+pf+vZBcgaC9dzsByTSz21GJOEoajZorV4b4phcsCswM10801kQ==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-body-length-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-1.0.0-alpha.2.tgz#2536808288485d97ede3906077fe079dd73cf39d"
+  integrity sha512-bApDyFpeWHzMOwz51MiT7imuIX/wJjxw06N8e3jMMWW8L1Z06tKFWg3u6HbMyYi13e7gBI//ZzoE8Enc9ritMw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-buffer-from@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-alpha.2.tgz#7185af5e7d3e7998078e4b973cd9b6de74c2707c"
+  integrity sha512-akddbV+cqrvMhZPhFzbBKc/bcZ2pnBTE1AsORsEzRcwdZ7agbgOI5LPw4kZKvwdc3zFyelYKrZUwoLe/6tb7dg==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/util-create-request@^0.1.0-preview.2":
@@ -669,6 +1042,13 @@
   dependencies:
     tslib "^1.8.0"
 
+"@aws-sdk/util-hex-encoding@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-alpha.2.tgz#f715e090ded81722e0d91ff286980beee9d46a6f"
+  integrity sha512-ZWNab7C5qUVD/CIHjRB1a5WPrhBuGYmV5z0J2DFbcuktyZ59iWEkk+k2t5X9RYbmkI3F8r/spvK7igl4I1BL9g==
+  dependencies:
+    tslib "^1.8.0"
+
 "@aws-sdk/util-locate-window@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-0.1.0-preview.1.tgz#7863359c64f194f289580843de416b7f66122244"
@@ -690,6 +1070,13 @@
   dependencies:
     tslib "^1.8.0"
 
+"@aws-sdk/util-uri-escape@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-1.0.0-alpha.2.tgz#83b46b66127abdf544d65a3b14bfb5523d4c742d"
+  integrity sha512-9Y/LkFpyY2M1dPTPpWilTN3ofClLl07R+AVOem72EAbXQZiebTLWopJOJxDMlWgrfNEsRrOQKrnfKCBE+U80PQ==
+  dependencies:
+    tslib "^1.8.0"
+
 "@aws-sdk/util-user-agent-browser@^0.1.0-preview.2":
   version "0.1.0-preview.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-0.1.0-preview.2.tgz#5bc7cdb3c20892fdd5c46eeddef54ad6c149e1f5"
@@ -706,6 +1093,22 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
+"@aws-sdk/util-user-agent-browser@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-1.0.0-alpha.3.tgz#57e357e492ccbd3d5b0493743cb9972d71b5bc11"
+  integrity sha512-5fLBCz7ZEXM9hM/IOppeGcZW9+buqPmLWro9nwvnBYE5FWgsodLTousi+q9lF8BHiI/8UvQ+/iyS0HlqOudRIg==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
+"@aws-sdk/util-user-agent-node@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-1.0.0-alpha.3.tgz#606dcb91bdff9e9add9f3bbd4c68e16aa90b4808"
+  integrity sha512-wz+UEGpvJ0VhbBZ8TRQqli5qJg93p4YHCxQ47G3vHHbe4R8GHG91h+M9HcstKTvBbwIs47zUwQxPWxQpZvVxDA==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.8.0"
+
 "@aws-sdk/util-utf8-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-0.1.0-preview.1.tgz#21142dfea0b143f8d73e0aabcbcafd76df1691f0"
@@ -718,6 +1121,21 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-0.1.0-preview.3.tgz#ee0f829a63f35d1bab23467c3e1e67f451e04816"
   integrity sha512-l97pohYxDjrew/cLgItvPo4HIrH3Se4PsEwZ2tgNhpA2+p9iWJFPy2Lppngx1sk5s6QhGF3x1g4G/0dGYIObgQ==
   dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-utf8-browser@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-alpha.2.tgz#b727d33ea1ea61ec85d5e141bfcae780f70c159d"
+  integrity sha512-/WhCITyFIkRfM8bGffgUOhnzCodJlVg1Jaq9Dr6whcDEkrvx6uDTsLnABAFn579uCnPeLrivJIE755PgUSHWiQ==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-utf8-node@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-1.0.0-alpha.2.tgz#378615850ea3ab0cb17bae88ff3dc793206f44a8"
+  integrity sha512-Lc+/mJiPcVEV0DJfMBnmqGuktlCX2tz/W7odUDMgCtBVNp97z5xK6aYcMSOQuCQofEGZzSaFHYqwBZLXGdFEJg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
 "@aws-sdk/xml-body-builder@^0.1.0-preview.4":

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     tslib "^1.9.3"
 
+"@aws-crypto/ie11-detection@^0.1.0-preview.4":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-0.1.0-preview.4.tgz#e25edd4e1da05df49e010ce2d1592f2f51d4765c"
+  integrity sha512-0cOu7FXHpJ7ddUDyjaYgCmEOhSYbMGgjqIuCLXzxOwY02V/RmVvi2bfFx0zsusgBbXCL+nqqS6BP/c5lGkDuYA==
+  dependencies:
+    tslib "^1.9.3"
+
 "@aws-crypto/sha256-browser@^0.1.0-preview.1":
   version "0.1.0-preview.3"
   resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-0.1.0-preview.3.tgz#949b64b5d8bd6087477088385b242b2bf2d665ce"
@@ -22,6 +29,19 @@
     "@aws-sdk/util-utf8-browser" "^0.1.0-preview.1"
     tslib "^1.9.3"
 
+"@aws-crypto/sha256-browser@^0.1.0-preview.4":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-0.1.0-preview.4.tgz#d7c2baae74d88508f7336a39feac7c7033c722ec"
+  integrity sha512-wP7hrVfwvJfPuQaHU1W32D0dqHU+MrW14qrqumFIiUEsGFhs0uM8dxy+SA7KKgNy4pdQfpZaNEyjlAwJAmATaQ==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^0.1.0-preview.4"
+    "@aws-crypto/sha256-js" "^0.1.0-preview.4"
+    "@aws-crypto/supports-web-crypto" "^0.1.0-preview.4"
+    "@aws-sdk/types" "^1.0.0-alpha.0"
+    "@aws-sdk/util-locate-window" "^1.0.0-alpha.0"
+    "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.0"
+    tslib "^1.9.3"
+
 "@aws-crypto/sha256-js@^0.1.0-preview.3":
   version "0.1.0-preview.3"
   resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-0.1.0-preview.3.tgz#c3994122288fdd4eaa63f059153e8ff79240ce8d"
@@ -31,6 +51,15 @@
     "@aws-sdk/util-utf8-browser" "^0.1.0-preview.1"
     tslib "^1.9.3"
 
+"@aws-crypto/sha256-js@^0.1.0-preview.4":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-0.1.0-preview.4.tgz#020f238888bbf998ef7b8c5d50a6e9548429c6bf"
+  integrity sha512-erEwxKLr+2s2Ni3EMlE2qBNOEExUmXFnpqCBS83SFc7Zg/+EUvcf4K0BBhf4jT/ZPIiZVYFymYz+yM7b4YZXqA==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.0"
+    "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.0"
+    tslib "^1.9.3"
+
 "@aws-crypto/supports-web-crypto@^0.1.0-preview.3":
   version "0.1.0-preview.3"
   resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-0.1.0-preview.3.tgz#480cdee0c0c6ae3516344880f88f192aa392348f"
@@ -38,12 +67,19 @@
   dependencies:
     tslib "^1.9.3"
 
-"@aws-sdk/abort-controller@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-1.0.0-alpha.2.tgz#cadc7608dd8f20eee2534590eef2d1bdfde14a79"
-  integrity sha512-f6MOmq7xFES9Z3JU4k9Eil8XB6Xg7XkomHWI//lcosbILmkj2skxjpK3+Xo25FbJws301tQdOnD6JoO+10obXg==
+"@aws-crypto/supports-web-crypto@^0.1.0-preview.4":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-0.1.0-preview.4.tgz#ef38218ce4df59da2d2b3b166c55669857facd18"
+  integrity sha512-P/cnFGz3A3SA4in2YVrU8CQAjf0n1WsC9Bv6LUqf5gL8wTaZvBl02ILjOpeOeQidaid+Fo//BLGi/55ksEj9Ug==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    tslib "^1.9.3"
+
+"@aws-sdk/abort-controller@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-1.0.0-alpha.3.tgz#24ea31bb187322355b4e282d01e30bd59a2592f0"
+  integrity sha512-wOOICJN7lO6G9nuLVHG2kdQA1Fos1wAwv375/y4onIwsOHQzC0rQZGU7Q4v9/+QPpsic4isu5pXaEptph/XjJA==
+  dependencies:
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/apply-body-checksum-middleware@^0.1.0-preview.4":
@@ -99,39 +135,39 @@
     "@aws-sdk/util-utf8-browser" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/client-dynamodb@^1.0.0-alpha.6":
-  version "1.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-1.0.0-alpha.6.tgz#2bb4dbad9f9d78d9e3e087845976645c4d5fe121"
-  integrity sha512-pMxy/gUg7MUS1NxtuqtlJbTCDY3GLBBbAHdkmLso+FAjthMHpQbGyMuJFc6L2eogkLI/GUP8JcUKfZJ7jvS/VA==
+"@aws-sdk/client-dynamodb@^1.0.0-alpha.10":
+  version "1.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-1.0.0-alpha.10.tgz#b5d894dbc52cb4e4f3c70abb1371d2c204e40ccb"
+  integrity sha512-X2DAPHd34fq2GqUf04E2PaYh5KzR/8yzrWqyWjU/v8uv5wPVtOEjayj3oLgSLmAutbS+wHkWMLWNbotas/4M2g==
   dependencies:
-    "@aws-crypto/sha256-browser" "^0.1.0-preview.1"
-    "@aws-sdk/config-resolver" "^1.0.0-alpha.4"
-    "@aws-sdk/credential-provider-node" "^1.0.0-alpha.2"
-    "@aws-sdk/fetch-http-handler" "^1.0.0-alpha.3"
-    "@aws-sdk/hash-node" "^1.0.0-alpha.2"
+    "@aws-crypto/sha256-browser" "^0.1.0-preview.4"
+    "@aws-sdk/config-resolver" "^1.0.0-alpha.7"
+    "@aws-sdk/credential-provider-node" "^1.0.0-alpha.3"
+    "@aws-sdk/fetch-http-handler" "^1.0.0-alpha.5"
+    "@aws-sdk/hash-node" "^1.0.0-alpha.3"
     "@aws-sdk/invalid-dependency" "^1.0.0-alpha.2"
-    "@aws-sdk/middleware-content-length" "^1.0.0-alpha.3"
-    "@aws-sdk/middleware-host-header" "^1.0.0-alpha.3"
-    "@aws-sdk/middleware-retry" "^1.0.0-alpha.3"
-    "@aws-sdk/middleware-serde" "^1.0.0-alpha.2"
-    "@aws-sdk/middleware-signing" "^1.0.0-alpha.4"
-    "@aws-sdk/middleware-stack" "^1.0.0-alpha.2"
-    "@aws-sdk/middleware-user-agent" "^1.0.0-alpha.3"
-    "@aws-sdk/node-http-handler" "^1.0.0-alpha.3"
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/region-provider" "^1.0.0-alpha.2"
-    "@aws-sdk/smithy-client" "^1.0.0-alpha.2"
-    "@aws-sdk/stream-collector-browser" "^1.0.0-alpha.2"
-    "@aws-sdk/stream-collector-node" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
-    "@aws-sdk/url-parser-browser" "^1.0.0-alpha.2"
-    "@aws-sdk/url-parser-node" "^1.0.0-alpha.2"
+    "@aws-sdk/middleware-content-length" "^1.0.0-alpha.5"
+    "@aws-sdk/middleware-host-header" "^1.0.0-alpha.5"
+    "@aws-sdk/middleware-retry" "^1.0.0-alpha.5"
+    "@aws-sdk/middleware-serde" "^1.0.0-alpha.3"
+    "@aws-sdk/middleware-signing" "^1.0.0-alpha.7"
+    "@aws-sdk/middleware-stack" "^1.0.0-alpha.3"
+    "@aws-sdk/middleware-user-agent" "^1.0.0-alpha.5"
+    "@aws-sdk/node-http-handler" "^1.0.0-alpha.5"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/region-provider" "^1.0.0-alpha.3"
+    "@aws-sdk/smithy-client" "^1.0.0-alpha.3"
+    "@aws-sdk/stream-collector-browser" "^1.0.0-alpha.3"
+    "@aws-sdk/stream-collector-node" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
+    "@aws-sdk/url-parser-browser" "^1.0.0-alpha.3"
+    "@aws-sdk/url-parser-node" "^1.0.0-alpha.3"
     "@aws-sdk/util-base64-browser" "^1.0.0-alpha.2"
     "@aws-sdk/util-base64-node" "^1.0.0-alpha.2"
     "@aws-sdk/util-body-length-browser" "^1.0.0-alpha.2"
     "@aws-sdk/util-body-length-node" "^1.0.0-alpha.2"
-    "@aws-sdk/util-user-agent-browser" "^1.0.0-alpha.3"
-    "@aws-sdk/util-user-agent-node" "^1.0.0-alpha.3"
+    "@aws-sdk/util-user-agent-browser" "^1.0.0-alpha.5"
+    "@aws-sdk/util-user-agent-node" "^1.0.0-alpha.5"
     "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.2"
     "@aws-sdk/util-utf8-node" "^1.0.0-alpha.2"
     tslib "^1.8.0"
@@ -188,13 +224,13 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/config-resolver@^1.0.0-alpha.4":
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-1.0.0-alpha.4.tgz#d80070744b157270591f851dfb30dad2ac4d6355"
-  integrity sha512-UGZ87h+UCzC6SwadbGOJS4wCv/LOxHEC9uIc/FfIjhed5DJcc6vDpANw+yLoq89BP0SKbpMavPLA4zkLVdXj4g==
+"@aws-sdk/config-resolver@^1.0.0-alpha.7":
+  version "1.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-1.0.0-alpha.7.tgz#c2f8bb85c92f459eee97ef5d4650a3eb1515c08c"
+  integrity sha512-6J6KxItBrMk4OUQH3xKU57V0Gq8FwD6oaF8MKOUSN7s8vqt09LXm0IeDKHdLmpKVjf5V6O410Ema0cg1m59yhA==
   dependencies:
-    "@aws-sdk/signature-v4" "^1.0.0-alpha.4"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/signature-v4" "^1.0.0-alpha.7"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/core-handler@^0.1.0-preview.1":
@@ -224,57 +260,57 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-env@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-1.0.0-alpha.2.tgz#206c1eccfccec0112d73e83d9be8ceae2669398e"
-  integrity sha512-6ux0bIp7yEjt9OLyy6O0k3HN1rZjthnQmvS6ryyIM6vCTGT37s7ys5BPqTdbg3U87F0enLMsZCkxdKM97eyTxA==
+"@aws-sdk/credential-provider-env@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-1.0.0-alpha.3.tgz#4a968524ead9da92ac54ccecba472c984d47027b"
+  integrity sha512-oKoqEccnGwuKGobIqnbIlHsjpVP8N6r3PD+/iejlthcrnBb0fRNv7NWQlt7FHQiJmva9wbTQ8ZwjbQDRGoX9Kg==
   dependencies:
-    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
-    "@aws-sdk/protocol-timestamp" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.3"
+    "@aws-sdk/protocol-timestamp" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-imds@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-1.0.0-alpha.2.tgz#9212b8d44d3c73fb2c5877d21516e622cd7af90b"
-  integrity sha512-p0ApBjQ4eUSN0WEl2yPPO2P6zR99sAw/uz9SZ5Lc80lhOtQ2t6wZ66eydCxcaHmwR1xZV4L8CRsPi+LyZwOPgw==
+"@aws-sdk/credential-provider-imds@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-1.0.0-alpha.3.tgz#99b2dd5a08b162522b5fb82e7474d0b1dad51edd"
+  integrity sha512-mN0l+syAtUljoFk3FJven5CP91NCHsKviC97WX6MVN0zrqJ7UXboxrYbEEYI/Buv03qj4YY2LTCX2xddXFxOnA==
   dependencies:
-    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-ini@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-1.0.0-alpha.2.tgz#8d344451a537b0c0332d0c89ecf98767561c8409"
-  integrity sha512-qzuZdiL177W3jjLMrpOz1ilobemGKKq4HpBcxtc0OhctwkLBSCO/drDwwhjfJucBGJcQP+OnubdcM+MBxaPgJg==
+"@aws-sdk/credential-provider-ini@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-1.0.0-alpha.3.tgz#89072b4c17974d480e43c91151733b8f1789a0fd"
+  integrity sha512-prUocW0N4kK7D/KqE6k31Ok9fAErp6hG59eEaqNVyxnexchYCFbHsG2DREW2YddXFb3jQFTKebIUuIMmyRL/BQ==
   dependencies:
-    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.3"
     "@aws-sdk/shared-ini-file-loader" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-node@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-1.0.0-alpha.2.tgz#01f5cfbc9450f815c35e966f1597228add5110a8"
-  integrity sha512-8HNFtzt2OWlUmM5H9ec8+InN8GQpTmNP7ejWwFtCgkWVqfwWkgVs0gNg2zWuJFfAg+b+WLqHQGq+Xd8Vcy9H/g==
+"@aws-sdk/credential-provider-node@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-1.0.0-alpha.3.tgz#978f60845a0898581813eb260f10cbac4d949146"
+  integrity sha512-ttp5gi/nwwYhtAkesIKDH5TZCQJklorwCCTZhc1G8OKHb/GgwgjINoA5/JCE8K1S6zKi3SaQs332ghSyuw5R1A==
   dependencies:
-    "@aws-sdk/credential-provider-env" "^1.0.0-alpha.2"
-    "@aws-sdk/credential-provider-imds" "^1.0.0-alpha.2"
-    "@aws-sdk/credential-provider-ini" "^1.0.0-alpha.2"
-    "@aws-sdk/credential-provider-process" "^1.0.0-alpha.2"
-    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/credential-provider-env" "^1.0.0-alpha.3"
+    "@aws-sdk/credential-provider-imds" "^1.0.0-alpha.3"
+    "@aws-sdk/credential-provider-ini" "^1.0.0-alpha.3"
+    "@aws-sdk/credential-provider-process" "^1.0.0-alpha.3"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-process@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-1.0.0-alpha.2.tgz#6395a033d390e70bd9cc8cf9f99096632773859a"
-  integrity sha512-106a1jjVoj4jdBlAkL06xRPk6gmJqGKF9IqGff81xs/DiIz9qjrEZKFFQwJwYRuOwpJQpI6xIeYx77nRu8/6cA==
+"@aws-sdk/credential-provider-process@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-1.0.0-alpha.3.tgz#9a252c71be0b3913a099322dcf2f9686769e8b73"
+  integrity sha512-3uRfKjY9GYzBVDSqAbai7mEPPTsFmwijKdH6kVxBfNKO6c1drHs1PMA5mOMTVYVAvW/P1gXft7S/XRuQrfdf5Q==
   dependencies:
-    "@aws-sdk/credential-provider-ini" "^1.0.0-alpha.2"
-    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/credential-provider-ini" "^1.0.0-alpha.3"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.3"
     "@aws-sdk/shared-ini-file-loader" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/fetch-http-handler@^0.1.0-preview.1":
@@ -295,14 +331,14 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/fetch-http-handler@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-alpha.3.tgz#387c50824931543c83856eb02496b9807cdc2984"
-  integrity sha512-uYWktJQvA8vzY0DVnepGJgrVhtXwKwwaOv4dl4vqBWI4Ou9b2rSluN/A6xQRi056r5FD11T4805oNXhIw1VcTg==
+"@aws-sdk/fetch-http-handler@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-alpha.5.tgz#d44687b592eca69b89749ac872b18c8d8e51f2b4"
+  integrity sha512-eBhhkFCv+DennkCh8FlQbsnyghKmwwmRL+4128mgKd9VLMBm8zHLlnm/D3MvMrhVGQSogjs3phy5d0303lOJTA==
   dependencies:
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/querystring-builder" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/querystring-builder" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/hash-blob-browser@^0.1.0-preview.5":
@@ -314,12 +350,12 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/hash-node@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-1.0.0-alpha.2.tgz#a2d20d05de7ca22bf332e75177adb94c910fb077"
-  integrity sha512-dRotBDMsez8025XpC3f0b02wtoy+MdIN/BTLEsQrBdIUP85VmT8Jk6oJ1zrAGY7hm4GAZD78Lm13HLbkB3+17Q==
+"@aws-sdk/hash-node@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-1.0.0-alpha.3.tgz#c36729406e7d8f44f1daed1af07b84fd04eb2c55"
+  integrity sha512-w23BkjJM2lY++kS0kXrAfRY6CK/+IXG+hdHGLPuqpT6J2ayYO3j2VaIeUVRuyMW8IX9WSY7ly27yC1m/eQSSMQ==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     "@aws-sdk/util-buffer-from" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
@@ -427,13 +463,13 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-content-length@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-alpha.3.tgz#f38adc78be2e2be3be52d4969f26d4bc73e427e7"
-  integrity sha512-ISfJkE+MTK83ntGZkuwCkwArWwxdz5b5hNkjIIu9C7SFV2ZpfrOBRw+ZnioCDo1Vv2mP3wusO55VVvYbkIQ2Zg==
+"@aws-sdk/middleware-content-length@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-alpha.5.tgz#d624d25115f90a6f2c8eb5d62e11411912f96e68"
+  integrity sha512-NeMR2Fiw5ngAM7TheooFVd6qVd+qmtOq2uYOoAeiW2MrqmbvXCmCsO5Lwx5JsibnQLShGjqiZuPdHGbbG3y67Q==
   dependencies:
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/middleware-header-default@^0.1.0-preview.1":
@@ -452,30 +488,30 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-host-header@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-1.0.0-alpha.3.tgz#bfcec9e1ab65dfcd12b5efd281b752c3cf441e4a"
-  integrity sha512-nzy4aSSHg2vtC/qsRKZ7Y3CUKxLIVduAOqGq0hYL6zWoyCDcoMdSwTKYjR8XmW5tPBeEwsm2oEfutbm+tv2mvg==
+"@aws-sdk/middleware-host-header@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-1.0.0-alpha.5.tgz#7a58f88cba5079b7745184bf165903dd1aa11bb5"
+  integrity sha512-sBF51VY8V22meFNXfD6VphLJOGx8aomfbAxuoolm0LTd1v98hAH5Mng8qKsC/UPxUeakw5vgCDVbWktN0JPuMQ==
   dependencies:
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-retry@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-alpha.3.tgz#e8dc678db970106019bbb5ae9f4c5d6c22aefb29"
-  integrity sha512-TU/9bv27H418uMvQR1KddFhyBO7D+R5i4uR9UV+qjSz1jch2y3u6Nmot6ISsWCGdIT+wxhRXsV8BJml16lL+3w==
+"@aws-sdk/middleware-retry@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-alpha.5.tgz#2f46224774942a145d2f5d58d04a2a0f9f925993"
+  integrity sha512-sI8Yau6xyAigJXOgrPXWXTQ5M4Eq2BIl1VKSl42qQqdOLv7to4kfSHsaiWB6dJ2lLhRe6vCo8fsHENcF66yCvQ==
   dependencies:
     "@aws-sdk/service-error-classification" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-serde@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-1.0.0-alpha.2.tgz#7e0984833a66931779d0935a9423aace10678a95"
-  integrity sha512-Pkv67GrtXgqoeX+XWAd/G/T1YAhcunVwWh9zD1+nIeWNyrI7wGzrWRbhYCgvCsL+qf9kxyd6fV5jGu6dBlfLXg==
+"@aws-sdk/middleware-serde@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-1.0.0-alpha.3.tgz#6fd611c1a13b46b9c3a3c3fa8fbe71dc9a09d2c2"
+  integrity sha512-g5N9amANNxAH10EDT0vrjKhbr2eCygCWdvMZagxQUnfM27CyKvSet/RuSbKRbRCbE22cB0H8RYh2FpC89BUGeQ==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/middleware-serializer@^0.1.0-preview.1":
@@ -494,14 +530,14 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-signing@^1.0.0-alpha.4":
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-1.0.0-alpha.4.tgz#97ad364434af219a225ee33b837b9093c64d6782"
-  integrity sha512-PlqJc/mQ9nMzipGjddiJ1fGcgVwzM9dKqVaSg/Me/+XpFASjHpUIf00DGWC3W/7dynRCFd+57KMBnvlz+grC+A==
+"@aws-sdk/middleware-signing@^1.0.0-alpha.7":
+  version "1.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-1.0.0-alpha.7.tgz#e5811a778b381095d79e7bb27605a5a649b46b7c"
+  integrity sha512-iYW1LdRZfrOzwJP+f5kXUebTVyhn+XsadccFSlH1PdKczahRN6iae/lF9FXnX0Ig5ewOOvo5OMXetSYtExfUOA==
   dependencies:
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/signature-v4" "^1.0.0-alpha.4"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/signature-v4" "^1.0.0-alpha.7"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/middleware-stack@^0.1.0-preview.2":
@@ -520,32 +556,32 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-stack@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-1.0.0-alpha.2.tgz#772aad64fb7f0725cbaff1967a3a1f518078ad15"
-  integrity sha512-meLHoDz0RlDIn1dC4eWgSmkr69ZyFua+QcSaWQG5IhzyG1x8zW2k49uYSaeUXS14mv8W+vHMQYCZLgrtFoUyNA==
+"@aws-sdk/middleware-stack@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-1.0.0-alpha.3.tgz#2b0122b2a660666d27d4f929ed7355d122b39c45"
+  integrity sha512-Dkney5WZC7ga+SpNjbT2FKuVZHsIJRnU0hMTG21kUAGjlQ2z2Sb0mEs96dSMynZ29zWBVkYjY/6qMZQEfnPowA==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-user-agent@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-1.0.0-alpha.3.tgz#0e2f120454f5a07aed688d5205a53fb76b6c216d"
-  integrity sha512-wtFcOf3QadfA0tc9rvjL9YIzlg90brjpqEmGWF1/k7cpWwHXiYbVN35I+FhrumGpTBpl8QqWzYnGttKGeBd4oA==
+"@aws-sdk/middleware-user-agent@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-1.0.0-alpha.5.tgz#8f487755e8e2f03349c52fa8095e5752fe110b2e"
+  integrity sha512-a+E0/lVBIdF+gjzJJUioPeI9s8cn4SzCt6IzuKWfvHUIHay5h7Su0A/bJuRs6l/7ZSlWKym6q2lw88s8E6jOrQ==
   dependencies:
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/node-http-handler@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-1.0.0-alpha.3.tgz#b03a9e1f6c47759161ef7e8c32a4fd0c7e63704d"
-  integrity sha512-VdeUPdi48CJRxZG5Q+sC2ErutPrnA3R2sUFRImxEeqRlQeyy7BkS+NvmN7TyxFVX85NgPpl+WWOO0LE1PLVs7A==
+"@aws-sdk/node-http-handler@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-1.0.0-alpha.5.tgz#f748bb64bfc6f9a9907c124dec1c2ecb16f1d8e4"
+  integrity sha512-Kclk5/kUzH2QposvICyvylmyE2RAJARk7vc5yNJ7q3o4rBb5krfaJpqYQNHQXDQYvipKp1Y9B31CZNQKaBhi0A==
   dependencies:
-    "@aws-sdk/abort-controller" "^1.0.0-alpha.2"
-    "@aws-sdk/protocol-http" "^1.0.0-alpha.3"
-    "@aws-sdk/querystring-builder" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/abort-controller" "^1.0.0-alpha.3"
+    "@aws-sdk/protocol-http" "^1.0.0-alpha.5"
+    "@aws-sdk/querystring-builder" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/property-provider@^0.1.0-preview.1":
@@ -556,20 +592,20 @@
     "@aws-sdk/types" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/property-provider@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-1.0.0-alpha.2.tgz#ad1fd38cfd8ce6bb860045b3ab1ab9e32280be9e"
-  integrity sha512-z/jVTlZz1k7TaK6nei4oRXv0/AL8hz13+lP6XLZJ3Ljiv5v/kIhPVZolytUEBzHAu+58d44y5JhdPWkiPs9JAA==
+"@aws-sdk/property-provider@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-1.0.0-alpha.3.tgz#38e22f69d01b7e7e5914a7b2817cfe7b42938be0"
+  integrity sha512-xTRR7gLnsgmec+c2RQPTvMcGCdk+0jRnoI5SxJy/BKPw/xquRxQYzN19eGumRc7fqzpouqUfdVYRu2ZzI2hKEg==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/protocol-http@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-1.0.0-alpha.3.tgz#552702d87e60aa09939bbcd467c3fb1912495cd6"
-  integrity sha512-+r1h57HOEsO6/PLZrpHwzV3U4JganGfTETsPZbJZ1pkg/sKJ8xeHta0W1LwuDtgiwUwSN3P4cbh1gEHCMv5efw==
+"@aws-sdk/protocol-http@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-1.0.0-alpha.5.tgz#289559d99f7a46c7eba177974b680572527cf104"
+  integrity sha512-DruwvhuulNyMH27fRtSEwGGHQNDEdtvTQZT7voDD49RXOU4B0HUlCOUXWhBMRivtbaoqF5JaKojFItOMO7J9UQ==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     "@aws-sdk/util-uri-escape" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
@@ -614,12 +650,12 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/protocol-timestamp@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-timestamp/-/protocol-timestamp-1.0.0-alpha.2.tgz#10a54cf647cc9c4d5c8de5268befdc060587c910"
-  integrity sha512-RMvn1M+b1cirX45EQy+TbDT71/CaMtRdZXqlIM9buXAJoWMDbHr/mVZb/6FMdujGwIctPX1RT375vdPVFlu37g==
+"@aws-sdk/protocol-timestamp@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-timestamp/-/protocol-timestamp-1.0.0-alpha.3.tgz#3f52e79fbe769be6886fc538c94f435206d8ee40"
+  integrity sha512-OOZiB3Gsf8HYVsdUbDk5xD9w52isqp8OozdINkpdg8ijzLbNGUUstBrXso9mxq58JM6myjo8T0pvAizbsuzljg==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/query-error-unmarshaller@^0.1.0-preview.5":
@@ -650,12 +686,12 @@
     "@aws-sdk/util-uri-escape" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/querystring-builder@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-1.0.0-alpha.2.tgz#8ba59c57ff2a09f3ade12025ae55cc0c6583c1a3"
-  integrity sha512-UzKLbCcYZs+csaQ/C/BKbSf8G3m+WHkfQpYlSEBPnqBKZrbWMzCT1fZ0N/mR573g9dYGVEg08UIyrtawyVDejQ==
+"@aws-sdk/querystring-builder@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-1.0.0-alpha.3.tgz#d73ad804ec85cfb19f343e3429a1918889557c1f"
+  integrity sha512-r+JageLnIAKGQGfkm7tegysel4QALdbde5LOYwJEzaFuYzILHpr+0fvO+ohJJfwDxl2fkwQfcTwsFmuZGPEncg==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     "@aws-sdk/util-uri-escape" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
@@ -675,22 +711,22 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/querystring-parser@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-1.0.0-alpha.2.tgz#cebd9f0b5869cfb4cb6d2d9afd6ba73332645bfd"
-  integrity sha512-QdahFldlVOr6bptZpAadyyXHU3kZ9DfBFj+rCp127EvmwX9ipNT1aClAN0e3gT39UgTfNOPWQL8lORZrmFHoOQ==
+"@aws-sdk/querystring-parser@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-1.0.0-alpha.3.tgz#d6949dc99a6352923ff631501e93aab7dc064c67"
+  integrity sha512-/W4QsGooBtDPOWhJUwKT6yuJG1hGF5ZbvN4XBXoawxcBky5pkFoHmgBQRLnPxho08S0BLrEolQg+iBwnkd54Xg==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/region-provider@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-1.0.0-alpha.2.tgz#2dc934327d6895d334bdd6d886932a345ac5f171"
-  integrity sha512-KWGU8kbHPUFUvz03bM56eX3qimt8/8Twlet0HdYOw4ZMOaSZouNSqICUoW10zaNJbB2OP0h7p6O5Sj0pa+7D7A==
+"@aws-sdk/region-provider@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-1.0.0-alpha.3.tgz#48e1b5374f73238f54f6eb096dd6bd972bc1667b"
+  integrity sha512-3iQK2qdfaGNNHH23v96BBZXx3ACQ/vhOpbegYHhl9RVwVn/s54G7sEgQnGPuOOhgnLPlFIVG0zHmjvwMtDWKIA==
   dependencies:
-    "@aws-sdk/property-provider" "^1.0.0-alpha.2"
+    "@aws-sdk/property-provider" "^1.0.0-alpha.3"
     "@aws-sdk/shared-ini-file-loader" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/response-metadata-extractor@^0.1.0-preview.2":
@@ -792,14 +828,14 @@
     "@aws-sdk/util-hex-encoding" "^0.1.0-preview.1"
     tslib "^1.8.0"
 
-"@aws-sdk/signature-v4@^1.0.0-alpha.4":
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-1.0.0-alpha.4.tgz#44eddb517dfc0b4d9d6f68493f96a130fb250bd2"
-  integrity sha512-sTrQWhYeyJj7lVRgEMvae4gh9DWBMDiReeVk8z40r54EqpholNckEp226SM2Yxj23Zffc/Ou6ny8wzwPv9Mu8w==
+"@aws-sdk/signature-v4@^1.0.0-alpha.7":
+  version "1.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-1.0.0-alpha.7.tgz#884398b8f8e9be200b67b99bcaa0064178d76a66"
+  integrity sha512-YaqWfZtgos1jMSyV4iNivfc0B48Aiu7gH9FzXLTQa1v9py+KiUqHPwWLVVPJpACc/KaU3f+78wBI1mTGlXfmlA==
   dependencies:
     "@aws-sdk/is-array-buffer" "^1.0.0-alpha.2"
-    "@aws-sdk/protocol-timestamp" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/protocol-timestamp" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     "@aws-sdk/util-hex-encoding" "^1.0.0-alpha.2"
     tslib "^1.8.0"
 
@@ -821,13 +857,13 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/smithy-client@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-1.0.0-alpha.2.tgz#ac6bed90759740558e9ff207a7f5e5a7a3add173"
-  integrity sha512-tIWeWNK4H24TJedBFhy+oCvzrsl6UvOKUoIChjiVTgZ7t63IkLKXU+4jxhojQVeGZkQEEqa6K5/5MbdkshQeKA==
+"@aws-sdk/smithy-client@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-1.0.0-alpha.3.tgz#2f8350904e58ea82c68a024d210ccd22df33d733"
+  integrity sha512-0kH2b0vB3/CxLo+EZ8mYy1AiZ3xCDSkhY+/hDgoYeuuoubPhmRDmxFVK0mKyvaAOd1JjBCKcTMFLXtdBVJGVWw==
   dependencies:
-    "@aws-sdk/middleware-stack" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/middleware-stack" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/ssec-middleware@^0.1.0-preview.4":
@@ -854,20 +890,20 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/stream-collector-browser@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-browser/-/stream-collector-browser-1.0.0-alpha.2.tgz#bbf7cc036bb1ef9575a6b9e8b5a08a4d406fd4a0"
-  integrity sha512-YBegxJzoykaqb59bPBU18RetxK20P3Dz7lYcTvKVle5xxBjkq+FI0jChSx5cN5fV/d/UTEkjMG5H5ptp7fDFmA==
+"@aws-sdk/stream-collector-browser@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-browser/-/stream-collector-browser-1.0.0-alpha.3.tgz#8774879efeb6a710550341dfd37380362c5b2709"
+  integrity sha512-auC4ZyJI8pUO+6r6UQHgVJ9+jLcluEs0RJvj5Q1vDvn/yJFH4V97b9kmOPKzJh0P9rwi1CigpNYM5fKltF9ILA==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/stream-collector-node@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-1.0.0-alpha.2.tgz#7b74371388f05133cedf2c8ff263e1777e73b85f"
-  integrity sha512-LN8sKskKGappvGWvjXZPUGbEhpA+cucfTJ8EjBF8PeICxkQfMuTOaU6dnZVEI+1j0wd1UTg/e/QaW6vtnnq2kw==
+"@aws-sdk/stream-collector-node@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-1.0.0-alpha.3.tgz#e3bc8eb1c0fa065cc9a8e8fd7bd4210e8d60ea70"
+  integrity sha512-SBBYKZp0ZVJ9Yj7uHEoThTaJz4H+deaFoGoQdFEe39+6yZnmiqg09WF8TGAyqUSnQFrVql7SbA+UNydOx6RPLA==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/types@^0.1.0-preview.1":
@@ -880,10 +916,10 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.7.tgz#2c3e8b911c9236e8f48d8ffb3c9df449a067df58"
   integrity sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw==
 
-"@aws-sdk/types@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-1.0.0-alpha.2.tgz#0d2895ed9ba7dfaf0a4bbaf47f477ff49c5eada0"
-  integrity sha512-IiRAkOfrRy4Ck1YlQ39oMxrZnbmiMUZGLmfFCC7WY3BrYy6kp+kZUwxcPUtjK4ZtlDHEPd6XiJeo2MQ68kkXSA==
+"@aws-sdk/types@^1.0.0-alpha.0", "@aws-sdk/types@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-1.0.0-alpha.3.tgz#cdf822d259ecef6b14fe55eb7c1c6eb45287f0cb"
+  integrity sha512-vndzXQm24/9TitocgMEV+VzjQF9awIHK5wnhyeAnmYxtxSYDT9ZYYghUuybfxRHQ7enR3vXuOoy2YnyJW4fb0w==
 
 "@aws-sdk/url-parser-browser@^0.1.0-preview.1":
   version "0.1.0-preview.1"
@@ -903,22 +939,22 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/url-parser-browser@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-browser/-/url-parser-browser-1.0.0-alpha.2.tgz#ff258f2a3af00f4f7b1b24cfdb99a25ab2f781cc"
-  integrity sha512-wxwWEdzNj4oPjti3soeuhvu0ELqOkdFEsQv7dZd4PaMXWpnD7c1TX2f6bQicGJxwzIfnB3+vK3R5uCU4u5B7aQ==
+"@aws-sdk/url-parser-browser@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-browser/-/url-parser-browser-1.0.0-alpha.3.tgz#d633cb244989c68f88fc90d25c8ddc8e54190813"
+  integrity sha512-lw9QhPdcoRBRiVsqUMFnNarXYGFELmkA9U+HkB9zI9Xr5ZXBkSTaD0hVzlVvYuHY0I4Sv/FbUeSaqQB7MLkkQQ==
   dependencies:
-    "@aws-sdk/querystring-parser" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/querystring-parser" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/url-parser-node@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-1.0.0-alpha.2.tgz#f5330430437ba88198eaf0105eaab221691d099d"
-  integrity sha512-GSFLb+wCcHMX8ebb+vL9LlkCcrhOyPeEj5IhlEQfLQnZ9n7Sl7G3wYizcptWtxARNHJXoAKwcMpOZHVSDi1Exw==
+"@aws-sdk/url-parser-node@^1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-1.0.0-alpha.3.tgz#0939e6b91a0b85effe759d3292e942fdff4da181"
+  integrity sha512-vwAbWXFGvGZj/n44cMQLx6K/cL4joOqmESXm18SIpgd3y9vxOITX5JVckHhteMVYQmo8SSOkOYCKMpSiHaYT+g==
   dependencies:
-    "@aws-sdk/querystring-parser" "^1.0.0-alpha.2"
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/querystring-parser" "^1.0.0-alpha.3"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/util-base64-browser@^0.1.0-preview.1":
@@ -1056,6 +1092,13 @@
   dependencies:
     tslib "^1.8.0"
 
+"@aws-sdk/util-locate-window@^1.0.0-alpha.0":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-alpha.2.tgz#f986bb286e9508edfc12fa5630c192005000280b"
+  integrity sha512-uMnAjOrjxBBp/aC/AiMkjwI5gq4PCZ1vBkt42333h0QjYZYUPiN43WA6FTo6zGC7HIBWmGk8xSMT2JfwWf5xsQ==
+  dependencies:
+    tslib "^1.8.0"
+
 "@aws-sdk/util-uri-escape@^0.1.0-preview.1":
   version "0.1.0-preview.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-0.1.0-preview.1.tgz#2036604d6f269fa896e3afeca9c8bbd7078c174f"
@@ -1093,20 +1136,20 @@
     "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/util-user-agent-browser@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-1.0.0-alpha.3.tgz#57e357e492ccbd3d5b0493743cb9972d71b5bc11"
-  integrity sha512-5fLBCz7ZEXM9hM/IOppeGcZW9+buqPmLWro9nwvnBYE5FWgsodLTousi+q9lF8BHiI/8UvQ+/iyS0HlqOudRIg==
+"@aws-sdk/util-user-agent-browser@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-1.0.0-alpha.5.tgz#09b17b3c7020398f683a40e2ff4f25e4bd9b5b8f"
+  integrity sha512-Fcy9gUgvMRTY8VDEiVI8P/a6ciAHBxO3eRTWFB6NuWL0degdJUdpfKjIz3sZ0Q5f8rUuW1m2g0E/Q3Cs8g1q2w==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
-"@aws-sdk/util-user-agent-node@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-1.0.0-alpha.3.tgz#606dcb91bdff9e9add9f3bbd4c68e16aa90b4808"
-  integrity sha512-wz+UEGpvJ0VhbBZ8TRQqli5qJg93p4YHCxQ47G3vHHbe4R8GHG91h+M9HcstKTvBbwIs47zUwQxPWxQpZvVxDA==
+"@aws-sdk/util-user-agent-node@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-1.0.0-alpha.5.tgz#69446ea2c42087de3d28845dd2efd34c7c211320"
+  integrity sha512-jLqi4S+QLcO/SCEtebK+jHTmarCN9Q8sWh4xWcSRkPpbzZa1IYCKrMpshga7EASfZBqXW2Bl804+6mqGEHdVCQ==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.2"
+    "@aws-sdk/types" "^1.0.0-alpha.3"
     tslib "^1.8.0"
 
 "@aws-sdk/util-utf8-browser@^0.1.0-preview.1":
@@ -1123,7 +1166,7 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/util-utf8-browser@^1.0.0-alpha.2":
+"@aws-sdk/util-utf8-browser@^1.0.0-alpha.0", "@aws-sdk/util-utf8-browser@^1.0.0-alpha.2":
   version "1.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-alpha.2.tgz#b727d33ea1ea61ec85d5e141bfcae780f70c159d"
   integrity sha512-/WhCITyFIkRfM8bGffgUOhnzCodJlVg1Jaq9Dr6whcDEkrvx6uDTsLnABAFn579uCnPeLrivJIE755PgUSHWiQ==


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* update Exercise2/backend to use @aws-sdk/client-dynamodb@alpha
* verified that the dynamodb operations work as expected

The file size of the lambdas have increased to 32kB though (refs: https://github.com/aws/aws-sdk-js-v3/issues/693)
<img width="669" alt="Screen Shot 2020-01-23 at 5 56 04 PM" src="https://user-images.githubusercontent.com/16024985/73039412-ce4d7800-3e0a-11ea-946a-b6f216587cab.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
