### PR TITLE
Remove credentials hack

### DIFF
--- a/Exercise2/frontend/src/libs/s3Client.ts
+++ b/Exercise2/frontend/src/libs/s3Client.ts
@@ -3,10 +3,8 @@ import { fromCognitoIdentityPool } from "@aws-sdk/credential-provider-cognito-id
 import { CognitoIdentityClient } from "@aws-sdk/client-cognito-identity-browser";
 import { config } from "../config";
 
-// Customization pending https://github.com/aws/aws-sdk-js-v3/issues/185
 const cognitoIdentityClient = new CognitoIdentityClient({
   region: "us-west-2",
-  credentials: () => Promise.resolve({} as any),
   signer: {} as any
 });
 cognitoIdentityClient.middlewareStack.remove("SIGNATURE");


### PR DESCRIPTION
*Issue #, if available:* See [issue 185 in AWS SDK v3](https://github.com/aws/aws-sdk-js-v3/issues/185)

*Description of changes:*

Removes the empty credentials hack that was used to bypass a fixed TS compile error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
