### PR TITLE
chore(deps-dev): [security] bump bl to 4.0.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4196,9 +4196,9 @@ bindings@^1.5.0:
     file-uri-to-path "1.0.0"
 
 bl@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
-  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"


### PR DESCRIPTION
*Issue #, if available:*
CVE https://github.com/advisories/GHSA-pp7h-53gx-mx7r

*Description of changes:*
bump bl to 4.0.3

```console
$ yarn why bl                                                 
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "bl"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "bl@4.0.3"
info Reasons this module exists
   - "_project_#@aws-sdk-workshop#infra#aws-cdk#archiver#tar-stream" depends on it
   - Hoisted from "_project_#@aws-sdk-workshop#infra#aws-cdk#archiver#tar-stream#bl"
info Disk size without dependencies: "396KB"
info Disk size with unique dependencies: "1.03MB"
info Disk size with transitive dependencies: "1.25MB"
info Number of shared dependencies: 10
✨  Done in 1.33s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
