### PR TITLE
chore(deps-dev): [security] bump node-notifier to 8.0.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14976,8 +14976,8 @@ fsevents@^1.2.7:
   linkType: hard
 
 "node-notifier@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "node-notifier@npm:8.0.0"
+  version: 8.0.1
+  resolution: "node-notifier@npm:8.0.1"
   dependencies:
     growly: ^1.3.0
     is-wsl: ^2.2.0
@@ -14985,7 +14985,7 @@ fsevents@^1.2.7:
     shellwords: ^0.1.1
     uuid: ^8.3.0
     which: ^2.0.2
-  checksum: 3016eccb32cbfc0ec26129500570a0d875c32e28c43aef9c32d4cea24617cdd870eaf39247faffed5b89f78ef69ca4506270d2f8f76f027222597b700cc8aec9
+  checksum: ce9611cfd8a6021b9aed5b9ad36e4717b9e151b46fe2f434408791291d261e695f3f397000e61edf23f2d1e5d2b73390abeb04b81754a9cfa95f68cfb2954cf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_Issue #, if available:_
Refs: https://github.com/facebook/jest/issues/10952#issuecomment-745370178

_Description of changes:_
[security] bump node-notifier to 8.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
